### PR TITLE
Add AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+environment:
+  matrix:
+    - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python35-x64"
+    - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python36-x64"
+
+install:
+  # AppVeyor does not initialise submodules by default, unlike Travis CI
+  - git submodule update --init --recursive
+  - "%PYTHON%/python.exe -m pip install wheel pybind11"
+
+build_script:
+  - "%PYTHON%/python.exe setup.py bdist_wheel"
+
+test_script:
+  # Ensure that the wheel is installable. It should be, but let's check anyway.
+  - ps: |
+      &"${env:PYTHON}/python.exe" -m pip install (ls dist/*.whl)
+
+artifacts:
+  - path: dist\*
+
+deploy_script:
+  - ps: |
+      If ($env:APPVEYOR_REPO_TAG -eq "true") {
+        &"${env:PYTHON}/python.exe" -m pip install twine
+        &"${env:PYTHON}/python.exe" -m twine upload dist/*.whl
+      }


### PR DESCRIPTION
This configures AppVeyor to build wheels for Python 3.5 and 3.6, for 32- and 64-bit, on Windows, and uploads them to PyPI on tags.

The `TWINE_USERNAME` and `TWINE_PASSWORD` environment variables will need to be configured in the AppVeyor web UI.